### PR TITLE
Added the header and side nav selectors into meetingsHome objects file

### DIFF
--- a/src/objects/meetingsHome.ts
+++ b/src/objects/meetingsHome.ts
@@ -1,0 +1,38 @@
+import { Locator, Page } from '@playwright/test';
+
+export class ProductOnePage {
+  readonly page: Page;
+
+  // Header
+  readonly hamburgerIcon: Locator;
+  readonly ParabolLogo: Locator;
+  readonly helpMenu: Locator;
+  readonly notifBell: Locator;
+  readonly userIcon: Locator;
+
+  // Side Nav
+  readonly meetingsSide: Locator;
+  readonly timelineSide: Locator;
+  readonly tasksSide: Locator;
+  readonly teamSide: Locator;
+  readonly addTeamSide: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+
+    // Header
+    this.hamburgerIcon = page.locator('button[aria-label="Toggle dashboard menu"]');
+    this.ParabolLogo = page.locator('button >> .css-1tiimx7');
+    this.helpMenu = page.locator('button[aria-label="Help menu"]');
+    this.notifBell = page.locator('button[aria-label="Notifications"]');
+    this.userIcon = page.locator('button >> .css-clypkz');
+
+    // Side Nav
+    this.meetingsSide = page.locator('button:has-text("Meetings")');
+    this.timelineSide = page.locator('button:has-text("Timeline")');
+    this.tasksSide = page.locator('button:has-text("Tasks")');
+    this.teamSide = page.locator('button >> .css-11nec0l');
+    this.addTeamSide = page.locator('button:has-text("Add a Team")');
+
+  }
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, motivation, and context. Screenshots or video recordings are encouraged. -->

Added the selectors from the images below (the header and side nav) into the meetingsHome objects file.

<img width="217" alt="Screen Shot 2022-05-01 at 10 25 45 AM" src="https://user-images.githubusercontent.com/22282866/166152787-a0682a43-6524-462b-90a1-f5b9efebe1e6.png">
<img width="1041" alt="Screen Shot 2022-05-01 at 10 26 23 AM" src="https://user-images.githubusercontent.com/22282866/166152812-ab40af26-ca69-4645-a66c-12e0d7faf748.png">

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

 - [x] Checked to see if my selectors were more resilient than the ones generated by codegen.
 
 ### Type of Test Done: <!-- Delete the ones that do not apply -->
 
  - Manual
  
  ## Checklist
   - [x] I have added a GitHub label for the type of change (Bug Fix, New Test, Breaking Change, Refactor).
   - [x] I have confirmed that all tests passed.
   - [x] I have performed a self-review of my own code.
   - [x] I can't think of any additional scenarios to test.
